### PR TITLE
BDH-69 feat: Add UserOperation to model for Improved Bundler-Solver Communication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,25 @@ jobs:
     - name: Run tests
       run: go test ./...
 
+    - name: Create GitHub App Token
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+
     - name: Calculate next version tag
       id: nextver
       uses: mathieudutour/github-tag-action@v5.6
       with:
-        github_token: ${{ secrets.SECRET_TOKEN }}
+        github_token: ${{ steps.app-token.outputs.token }}
         default_bump: minor
 
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.SECRET_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       with:
           tag_name: ${{ steps.nextver.outputs.new_tag }}
           release_name: Release ${{ steps.nextver.outputs.new_tag }}

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,14 @@ require (
 )
 
 require (
+	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/holiman/uint256 v1.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
+github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
@@ -7,6 +10,10 @@ github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583j
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/ethereum/go-ethereum v1.11.5 h1:3M1uan+LAUvdn+7wCEFrcMM4LJTeuxDrPTg/f31a5QQ=
 github.com/ethereum/go-ethereum v1.11.5/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -26,6 +33,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
+github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=

--- a/userops.go
+++ b/userops.go
@@ -1,0 +1,233 @@
+// Package model provides common data structures shared among blndgs projects.
+// This file has been copied from the Bundler project.
+// It is included in the model package to avoid introducing a cyclical dependency
+// between the Model and Bundler projects and accommodate Bundler<->Solver communication.
+// Any modifications made to the Bundler file should be reflected here as well to maintain consistency.
+//
+// Note: In the future, this file may move here as the single source of truth.
+package model
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	address, _ = abi.NewType("address", "", nil)
+	uint256, _ = abi.NewType("uint256", "", nil)
+	bytes32, _ = abi.NewType("bytes32", "", nil)
+
+	// UserOpPrimitives is the primitive ABI types for each UserOperation field.
+	UserOpPrimitives = []abi.ArgumentMarshaling{
+		{Name: "sender", InternalType: "Sender", Type: "address"},
+		{Name: "nonce", InternalType: "Nonce", Type: "uint256"},
+		{Name: "initCode", InternalType: "InitCode", Type: "bytes"},
+		{Name: "callData", InternalType: "CallData", Type: "bytes"},
+		{Name: "callGasLimit", InternalType: "CallGasLimit", Type: "uint256"},
+		{Name: "verificationGasLimit", InternalType: "VerificationGasLimit", Type: "uint256"},
+		{Name: "preVerificationGas", InternalType: "PreVerificationGas", Type: "uint256"},
+		{Name: "maxFeePerGas", InternalType: "MaxFeePerGas", Type: "uint256"},
+		{Name: "maxPriorityFeePerGas", InternalType: "MaxPriorityFeePerGas", Type: "uint256"},
+		{Name: "paymasterAndData", InternalType: "PaymasterAndData", Type: "bytes"},
+		{Name: "signature", InternalType: "Signature", Type: "bytes"},
+	}
+
+	// UserOpType is the ABI type of a UserOperation.
+	UserOpType, _ = abi.NewType("tuple", "op", UserOpPrimitives)
+
+	// UserOpArr is the ABI type for an array of UserOperations.
+	UserOpArr, _ = abi.NewType("tuple[]", "ops", UserOpPrimitives)
+)
+
+// UserOperation represents an EIP-4337 style transaction for a smart contract account.
+type UserOperation struct {
+	Sender               common.Address `json:"sender"               mapstructure:"sender"               validate:"required"`
+	Nonce                *big.Int       `json:"nonce"                mapstructure:"nonce"                validate:"required"`
+	InitCode             []byte         `json:"initCode"             mapstructure:"initCode"             validate:"required"`
+	CallData             []byte         `json:"callData"             mapstructure:"callData"             validate:"required"`
+	CallGasLimit         *big.Int       `json:"callGasLimit"         mapstructure:"callGasLimit"         validate:"required"`
+	VerificationGasLimit *big.Int       `json:"verificationGasLimit" mapstructure:"verificationGasLimit" validate:"required"`
+	PreVerificationGas   *big.Int       `json:"preVerificationGas"   mapstructure:"preVerificationGas"   validate:"required"`
+	MaxFeePerGas         *big.Int       `json:"maxFeePerGas"         mapstructure:"maxFeePerGas"         validate:"required"`
+	MaxPriorityFeePerGas *big.Int       `json:"maxPriorityFeePerGas" mapstructure:"maxPriorityFeePerGas" validate:"required"`
+	PaymasterAndData     []byte         `json:"paymasterAndData"     mapstructure:"paymasterAndData"     validate:"required"`
+	Signature            []byte         `json:"signature"            mapstructure:"signature"            validate:"required"`
+}
+
+// GetPaymaster returns the address portion of PaymasterAndData if applicable. Otherwise it returns the zero
+// address.
+func (op *UserOperation) GetPaymaster() common.Address {
+	if len(op.PaymasterAndData) < common.AddressLength {
+		return common.HexToAddress("0x")
+	}
+
+	return common.BytesToAddress(op.PaymasterAndData[:common.AddressLength])
+}
+
+// GetFactory returns the address portion of InitCode if applicable. Otherwise it returns the zero address.
+func (op *UserOperation) GetFactory() common.Address {
+	if len(op.InitCode) < common.AddressLength {
+		return common.HexToAddress("0x")
+	}
+
+	return common.BytesToAddress(op.InitCode[:common.AddressLength])
+}
+
+// GetMaxGasAvailable returns the max amount of gas that can be consumed by this UserOperation.
+func (op *UserOperation) GetMaxGasAvailable() *big.Int {
+	// TODO: Multiplier logic might change in v0.7
+	mul := big.NewInt(1)
+	paymaster := op.GetPaymaster()
+	if paymaster != common.HexToAddress("0x") {
+		mul = big.NewInt(3)
+	}
+
+	return big.NewInt(0).Add(
+		big.NewInt(0).Mul(op.VerificationGasLimit, mul),
+		big.NewInt(0).Add(op.PreVerificationGas, op.CallGasLimit),
+	)
+}
+
+// GetMaxPrefund returns the max amount of wei required to pay for gas fees by either the sender or
+// paymaster.
+func (op *UserOperation) GetMaxPrefund() *big.Int {
+	return big.NewInt(0).Mul(op.GetMaxGasAvailable(), op.MaxFeePerGas)
+}
+
+// GetDynamicGasPrice returns the effective gas price paid by the UserOperation given a basefee. If basefee is
+// nil, it will assume a value of 0.
+func (op *UserOperation) GetDynamicGasPrice(basefee *big.Int) *big.Int {
+	bf := basefee
+	if bf == nil {
+		bf = big.NewInt(0)
+	}
+
+	gp := big.NewInt(0).Add(bf, op.MaxPriorityFeePerGas)
+	if gp.Cmp(op.MaxFeePerGas) == 1 {
+		return op.MaxFeePerGas
+	}
+	return gp
+}
+
+// Pack returns a standard message of the userOp. This cannot be used to generate a userOpHash.
+func (op *UserOperation) Pack() []byte {
+	args := abi.Arguments{
+		{Name: "UserOp", Type: UserOpType},
+	}
+	packed, _ := args.Pack(&struct {
+		Sender               common.Address
+		Nonce                *big.Int
+		InitCode             []byte
+		CallData             []byte
+		CallGasLimit         *big.Int
+		VerificationGasLimit *big.Int
+		PreVerificationGas   *big.Int
+		MaxFeePerGas         *big.Int
+		MaxPriorityFeePerGas *big.Int
+		PaymasterAndData     []byte
+		Signature            []byte
+	}{
+		op.Sender,
+		op.Nonce,
+		op.InitCode,
+		op.CallData,
+		op.CallGasLimit,
+		op.VerificationGasLimit,
+		op.PreVerificationGas,
+		op.MaxFeePerGas,
+		op.MaxPriorityFeePerGas,
+		op.PaymasterAndData,
+		op.Signature,
+	})
+
+	enc := hexutil.Encode(packed)
+	enc = "0x" + enc[66:]
+	return (hexutil.MustDecode(enc))
+}
+
+// PackForSignature returns a minimal message of the userOp. This can be used to generate a userOpHash.
+func (op *UserOperation) PackForSignature() []byte {
+	args := abi.Arguments{
+		{Name: "sender", Type: address},
+		{Name: "nonce", Type: uint256},
+		{Name: "hashInitCode", Type: bytes32},
+		{Name: "hashCallData", Type: bytes32},
+		{Name: "callGasLimit", Type: uint256},
+		{Name: "verificationGasLimit", Type: uint256},
+		{Name: "preVerificationGas", Type: uint256},
+		{Name: "maxFeePerGas", Type: uint256},
+		{Name: "maxPriorityFeePerGas", Type: uint256},
+		{Name: "hashPaymasterAndData", Type: bytes32},
+	}
+	packed, _ := args.Pack(
+		op.Sender,
+		op.Nonce,
+		crypto.Keccak256Hash(op.InitCode),
+		crypto.Keccak256Hash(op.CallData),
+		op.CallGasLimit,
+		op.VerificationGasLimit,
+		op.PreVerificationGas,
+		op.MaxFeePerGas,
+		op.MaxPriorityFeePerGas,
+		crypto.Keccak256Hash(op.PaymasterAndData),
+	)
+
+	return packed
+}
+
+// GetUserOpHash returns the hash of the userOp + entryPoint address + chainID.
+func (op *UserOperation) GetUserOpHash(entryPoint common.Address, chainID *big.Int) common.Hash {
+	return crypto.Keccak256Hash(
+		crypto.Keccak256(op.PackForSignature()),
+		common.LeftPadBytes(entryPoint.Bytes(), 32),
+		common.LeftPadBytes(chainID.Bytes(), 32),
+	)
+}
+
+// MarshalJSON returns a JSON encoding of the UserOperation.
+func (op *UserOperation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Sender               string `json:"sender"`
+		Nonce                string `json:"nonce"`
+		InitCode             string `json:"initCode"`
+		CallData             string `json:"callData"`
+		CallGasLimit         string `json:"callGasLimit"`
+		VerificationGasLimit string `json:"verificationGasLimit"`
+		PreVerificationGas   string `json:"preVerificationGas"`
+		MaxFeePerGas         string `json:"maxFeePerGas"`
+		MaxPriorityFeePerGas string `json:"maxPriorityFeePerGas"`
+		PaymasterAndData     string `json:"paymasterAndData"`
+		Signature            string `json:"signature"`
+	}{
+		Sender:               op.Sender.String(),
+		Nonce:                hexutil.EncodeBig(op.Nonce),
+		InitCode:             hexutil.Encode(op.InitCode),
+		CallData:             hexutil.Encode(op.CallData),
+		CallGasLimit:         hexutil.EncodeBig(op.CallGasLimit),
+		VerificationGasLimit: hexutil.EncodeBig(op.VerificationGasLimit),
+		PreVerificationGas:   hexutil.EncodeBig(op.PreVerificationGas),
+		MaxFeePerGas:         hexutil.EncodeBig(op.MaxFeePerGas),
+		MaxPriorityFeePerGas: hexutil.EncodeBig(op.MaxPriorityFeePerGas),
+		PaymasterAndData:     hexutil.Encode(op.PaymasterAndData),
+		Signature:            hexutil.Encode(op.Signature),
+	})
+}
+
+// ToMap returns the current UserOp struct as a map type.
+func (op *UserOperation) ToMap() (map[string]any, error) {
+	data, err := op.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var opData map[string]any
+	if err := json.Unmarshal(data, &opData); err != nil {
+		return nil, err
+	}
+	return opData, nil
+}

--- a/userops_ext.go
+++ b/userops_ext.go
@@ -33,7 +33,19 @@ import (
 )
 
 type BodyOfUserOps struct {
-	UserOps []*UserOperation `json:"user_ops" binding:"required,dive"`
+	UserOps    []*UserOperation   `json:"user_ops" binding:"required,dive"`
+	UserOpsExt []UserOperationExt `json:"user_ops_ext" binding:"required,dive"`
+}
+
+// UserOperationExt represents additional extended information about a UserOperation that will be communicated from the
+// Bundler to the Solver.
+// The Solver may change the sequence of UserOperations in the UserOperationExt slice to match the sequence of
+// UserOperations in the UserOps slice.
+// The `OriginalHashValue` field is the hash value of the UserOperation as it was calculated for the userOp submitted
+// by the wallet before the UserOperation is solved and it is a Read-Only field.
+type UserOperationExt struct {
+	OriginalHashValue string `json:"original_hash_value" mapstructure:"original_hash_value" validate:"required"`
+	ProcessingStatus  string `json:"processing_status" mapstructure:"processing_status" validate:"required"`
 }
 
 const IntentEndToken = "<intent-end>"

--- a/userops_ext.go
+++ b/userops_ext.go
@@ -1,0 +1,207 @@
+// Package model provides structures and methods for the communication between
+// the Bundler and Solver.
+// This file defines extensions to the UserOperation struct and methods for
+// extracting data from the CallData field.
+//
+// The Calldata field in a userOperation is expected to contain the intent json
+// value and or the calldata value for solved userOps or conventional userOps
+// respectively. The separator token is required when both intent json and
+// CallData values are present. The separator token is not required when either
+// the Intent or calldata value is present.
+//
+// The separator token is defined as "<intent-end>".
+//
+// <intent json><intent-end><calldata>
+//
+// 1. <Intent json>: The Intent JSON definition.
+//
+// 2. <intent-end>: A separator token to separate the Intent JSON from the CallData
+// value.
+//
+// 3. Ethereum Transaction CallData: a hexadecimal 0x prefixed value.
+//
+// The methods in this file provide functionalities to:
+//   - Check for the presence of Intent and/or Ethereum Transaction CallData.
+//   - Extract and separate the Intent and Ethereum Transaction CallData.
+package model
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/goccy/go-json"
+)
+
+type BodyOfUserOps struct {
+	UserOps []*UserOperation `json:"user_ops" binding:"required,dive"`
+}
+
+const IntentEndToken = "<intent-end>"
+
+type userOperationError string
+
+func (e userOperationError) Error() string {
+	return string(e)
+}
+
+// Define error constants
+const (
+	ErrNoIntentFound     userOperationError = "no Intent found"
+	ErrIntentInvalidJSON userOperationError = "invalid Intent JSON"
+	ErrNoSeparator       userOperationError = "separator token not found"
+	ErrNoCalldata        userOperationError = "no CallData found"
+)
+
+// extractIntentJSON attempts to extract the Intent JSON from the CallData field.
+// It returns the JSON as a string and a boolean indicating whether a valid JSON was found.
+func (u *UserOperation) extractIntentJSON() (string, bool) {
+	parts := strings.Split(string(u.CallData), IntentEndToken)
+	if len(parts) >= 1 {
+		var intent Intent
+		if err := json.Unmarshal([]byte(parts[0]), &intent); err == nil {
+			return parts[0], true
+		}
+	}
+	return "", false
+}
+
+// HasIntent checks if the CallData field contains a valid Intent JSON that
+// decodes successfully into an Intent struct.
+func (u *UserOperation) HasIntent() bool {
+	_, hasIntent := u.extractIntentJSON()
+	return hasIntent
+}
+
+// GetIntentJSON returns the Intent JSON from the CallData field, if present.
+func (u *UserOperation) GetIntentJSON() (string, error) {
+	intentJSON, hasIntent := u.extractIntentJSON()
+	if !hasIntent {
+		return "", ErrNoIntentFound
+	}
+	return intentJSON, nil
+}
+
+// GetIntent takes the Intent JSON from the CallData field, decodes it into
+// an Intent struct, and returns the struct.
+func (u *UserOperation) GetIntent() (*Intent, error) {
+	intentJSON, hasIntent := u.extractIntentJSON()
+	if !hasIntent {
+		return nil, ErrNoIntentFound
+	}
+
+	var intent Intent
+	if err := json.Unmarshal([]byte(intentJSON), &intent); err != nil {
+		return nil, ErrIntentInvalidJSON
+	}
+	return &intent, nil
+}
+
+// HasCallData returns true if the CallData field starts with "0x"
+// either directly or after the intent and separator token.
+func (u *UserOperation) HasCallData() bool {
+	parts := strings.Split(string(u.CallData), IntentEndToken)
+
+	// Check for CallData after the separator token
+	const hexPrefix = "0x"
+	if len(parts) >= 2 {
+		return strings.HasPrefix(parts[1], hexPrefix)
+	}
+
+	// Check for CallData directly if there's no separator token
+	return strings.HasPrefix(parts[0], hexPrefix)
+}
+
+// GetCallData extracts and returns the Ethereum transaction CallData from the CallData field.
+// It returns an error if the CallData value does not exist or does not start with "0x".
+func (u *UserOperation) GetCallData() ([]byte, error) {
+	parts := strings.Split(string(u.CallData), IntentEndToken)
+
+	var calldata string
+	if len(parts) >= 2 {
+		calldata = parts[1]
+	} else if len(parts) == 1 {
+		calldata = parts[0]
+	} else {
+		return nil, ErrNoCalldata
+	}
+
+	if !strings.HasPrefix(calldata, "0x") {
+		return nil, ErrNoCalldata
+	}
+
+	return []byte(calldata), nil
+}
+
+// RemoveIntent removes the Intent JSON and the separator token from the
+// CallData field and returns the Intent JSON.
+func (u *UserOperation) RemoveIntent() (string, error) {
+	intentJSON, err := u.GetIntentJSON()
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(string(u.CallData), IntentEndToken)
+	u.CallData = []byte(parts[1])
+
+	return intentJSON, nil
+}
+
+// RemoveCallData removes the CallData value from the CallData field and
+// returns its value.
+func (u *UserOperation) RemoveCallData() ([]byte, error) {
+	CallData, err := u.GetCallData()
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(string(u.CallData), IntentEndToken)
+	if len(parts) >= 2 {
+		u.CallData = []byte(parts[0] + IntentEndToken)
+	} else {
+		u.CallData = []byte{}
+	}
+	return CallData, nil
+}
+
+// SetIntent sets the Intent JSON part of the CallData field.
+func (u *UserOperation) SetIntent(intentJSON string) error {
+	if err := json.Unmarshal([]byte(intentJSON), new(Intent)); err != nil {
+		return ErrIntentInvalidJSON
+	}
+
+	callData, err := u.GetCallData()
+	if err != nil && !errors.Is(err, ErrNoCalldata) {
+		return err
+	}
+
+	if len(callData) > 0 {
+		u.CallData = []byte(intentJSON + IntentEndToken + string(callData))
+	} else {
+		// Don't add the separator token if there's no CallData
+		u.CallData = []byte(intentJSON)
+	}
+
+	return nil
+}
+
+// SetCallData sets the Ethereum transaction CallData part of the CallData field.
+func (u *UserOperation) SetCallData(callDataValue []byte) {
+	intentJSON, _ := u.GetIntentJSON()
+
+	if intentJSON != "" {
+		u.CallData = []byte(intentJSON + IntentEndToken + string(callDataValue))
+	} else {
+		u.CallData = callDataValue
+	}
+}
+
+// SetIntentAndCallData sets both the Intent JSON and the Ethereum transaction CallData
+// parts of the CallData field.
+func (u *UserOperation) SetIntentAndCallData(intentJSON string, callData []byte) error {
+	if err := json.Unmarshal([]byte(intentJSON), new(Intent)); err != nil {
+		return ErrIntentInvalidJSON
+	}
+
+	u.CallData = []byte(intentJSON + IntentEndToken + string(callData))
+
+	return nil
+}

--- a/userops_ext_test.go
+++ b/userops_ext_test.go
@@ -1,0 +1,174 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mockIntent() Intent {
+	return Intent{}
+}
+
+const callDataValue = "0xethereum_calldata"
+
+// mockValidIntentJSON creates a valid JSON string for testing the Intent.
+func mockValidIntentJSON() string {
+	return `{"key":"value"}`
+}
+
+// mockUserOperation creates a UserOperation with calldata for testing.
+func mockUserOperation(withIntent bool) *UserOperation {
+	var callDataFieldValue string
+
+	intent := mockIntent()
+
+	if withIntent {
+		intentJSON, _ := json.Marshal(intent)
+		callDataFieldValue = string(intentJSON)
+		callDataFieldValue += IntentEndToken + callDataValue
+	} else {
+		callDataFieldValue = callDataValue
+	}
+
+	return &UserOperation{CallData: []byte(callDataFieldValue)}
+}
+
+// TestUserOperation_HasIntent tests the HasIntent method.
+func TestUserOperation_HasIntent(t *testing.T) {
+	uoWithIntent := mockUserOperation(true)
+	uoWithoutIntent := mockUserOperation(false)
+
+	if !uoWithIntent.HasIntent() {
+		t.Errorf("HasIntent() = false; want true for calldata with intent")
+	}
+
+	if uoWithoutIntent.HasIntent() {
+		t.Errorf("HasIntent() = true; want false for calldata without intent")
+	}
+}
+
+// TestUserOperation_GetIntentJSON tests the GetIntentJSON method.
+func TestUserOperation_GetIntentJSON(t *testing.T) {
+	uoWithIntent := mockUserOperation(true)
+	uoWithoutIntent := mockUserOperation(false)
+
+	_, err := uoWithIntent.GetIntentJSON()
+	if err != nil {
+		t.Errorf("GetIntentJSON() with intent returned error: %v", err)
+	}
+
+	_, err = uoWithoutIntent.GetIntentJSON()
+	if err == nil {
+		t.Errorf("GetIntentJSON() without intent did not return error")
+	}
+}
+
+// TestUserOperation_GetIntent tests the GetIntent method.
+func TestUserOperation_GetIntent(t *testing.T) {
+	uoWithIntent := mockUserOperation(true)
+	uoWithoutIntent := mockUserOperation(false)
+
+	_, err := uoWithIntent.GetIntent()
+	if err != nil {
+		t.Errorf("GetIntent() with valid intent returned error: %v", err)
+	}
+
+	_, err = uoWithoutIntent.GetIntent()
+	if err == nil {
+		t.Errorf("GetIntent() without intent did not return error")
+	}
+}
+
+// TestUserOperation_GetCallData tests the GetCallData method.
+func TestUserOperation_GetCallData(t *testing.T) {
+	uoWithIntent := mockUserOperation(true)
+	uoWithoutIntent := mockUserOperation(false)
+
+	calldata, err := uoWithIntent.GetCallData()
+	if err != nil || string(calldata) != callDataValue {
+		t.Errorf("GetCallData() with intent did not return expected calldata")
+	}
+
+	calldata, err = uoWithoutIntent.GetCallData()
+	if err != nil || string(calldata) != callDataValue {
+		t.Errorf("GetCallData() without intent did not return expected calldata")
+	}
+}
+
+// TestUserOperation_RemoveIntent tests the RemoveIntent method.
+func TestUserOperation_RemoveIntent(t *testing.T) {
+	uoWithIntent := mockUserOperation(true)
+	uoWithoutIntent := mockUserOperation(false)
+
+	_, err := uoWithIntent.RemoveIntent()
+	if err != nil {
+		t.Errorf("RemoveIntent() with intent returned error: %v", err)
+	}
+	if uoWithIntent.HasIntent() {
+		t.Errorf("RemoveIntent() did not remove intent")
+	}
+
+	_, err = uoWithoutIntent.RemoveIntent()
+	if err == nil {
+		t.Errorf("RemoveIntent() without intent did not return error")
+	}
+}
+
+// TestUserOperation_RemoveCalldata tests the RemoveCalldata method.
+func TestUserOperation_RemoveCalldata(t *testing.T) {
+	uoWithIntent := mockUserOperation(true)
+
+	calldata, err := uoWithIntent.RemoveCallData()
+	if err != nil || string(calldata) != callDataValue {
+		t.Errorf("RemoveCalldata() did not return expected calldata")
+	}
+	if !uoWithIntent.HasIntent() {
+		t.Errorf("RemoveCalldata() removed the intent")
+	}
+
+	if uoWithIntent.HasCallData() {
+		t.Errorf("RemoveIntent() did not remove the CallData value")
+	}
+}
+
+// TestUserOperation_SetIntent tests the SetIntent method.
+func TestUserOperation_SetIntent(t *testing.T) {
+	uo := &UserOperation{}
+
+	// Test setting valid intent
+	validIntentJSON := mockValidIntentJSON()
+	if err := uo.SetIntent(validIntentJSON); err != nil {
+		t.Errorf("SetIntent() with valid intent returned error: %v", err)
+	}
+
+	// Test setting invalid intent
+	invalidIntentJSON := "invalid json"
+	if err := uo.SetIntent(invalidIntentJSON); err == nil {
+		t.Errorf("SetIntent() with invalid intent did not return error")
+	}
+}
+
+// TestUserOperation_SetCallData tests the SetCallData method.
+func TestUserOperation_SetCallData(t *testing.T) {
+	uo := &UserOperation{}
+
+	// Test setting valid CallData
+	validCallData := []byte("0x123")
+	uo.SetCallData(validCallData)
+	if string(uo.CallData) != string(validCallData) {
+		t.Errorf("SetCallData() did not set CallData correctly")
+	}
+}
+
+// TestUserOperation_SetIntentAndCallData tests the SetIntentAndCallData method.
+func TestUserOperation_SetIntentAndCallData(t *testing.T) {
+	uo := &UserOperation{}
+
+	// Test setting both valid intent and CallData
+	validIntentJSON := mockValidIntentJSON()
+	validCallData := []byte("0x123")
+	err := uo.SetIntentAndCallData(validIntentJSON, validCallData)
+	if err != nil {
+		t.Errorf("SetIntentAndCallData() with valid intent and CallData returned error: %v", err)
+	}
+}


### PR DESCRIPTION
This PR adds and extends the UserOperation struct in the model package.

New Data Structures: BodyOfUserOps and UserOperationExt for HTTP communication for the Gas estimations.

Calldata Handling: Implemented methods for handling the Calldata field, accommodating intent JSON and Ethereum transaction Calldata, with or without the <intent-end> separator.