### PR TITLE
BDH-106 Support unmarshaling of unsolved Intent userOps

### DIFF
--- a/userops_ext.go
+++ b/userops_ext.go
@@ -186,7 +186,7 @@ func (op *UserOperation) SetEVMInstructions(callDataValue []byte) {
 }
 
 // UnmarshalJSON does the reverse of the provided bundler custom
-// JSON marshaller for a UserOperation.
+// JSON marshaler for a UserOperation.
 func (op *UserOperation) UnmarshalJSON(data []byte) error {
 	aux := struct {
 		Sender               string `json:"sender"`

--- a/userops_ext.go
+++ b/userops_ext.go
@@ -219,9 +219,19 @@ func (op *UserOperation) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	op.CallData, err = hexutil.Decode(aux.CallData)
-	if err != nil {
-		return err
+	// If the CallData is not prefixed with "0x", it's likely an Intent JSON
+	if strings.HasPrefix(aux.CallData, "0x") {
+		op.CallData, err = hexutil.Decode(aux.CallData)
+		if err != nil {
+			return err
+		}
+	} else {
+		// test Intent JSON validity
+		if err := json.Unmarshal([]byte(aux.CallData), new(Intent)); err != nil {
+			return fmt.Errorf("%w: %s", ErrIntentInvalidJSON, err)
+		}
+
+		op.CallData = []byte(aux.CallData)
 	}
 
 	op.CallGasLimit, err = hexutil.DecodeBig(aux.CallGasLimit)

--- a/userops_ext_test.go
+++ b/userops_ext_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func mockIntent() Intent {
@@ -160,6 +161,147 @@ func TestUserOperation_UnmarshalJSON(t *testing.T) {
 	// Compare the original and unmarshaled instances
 	if !reflect.DeepEqual(originalOp, &unmarshaledOp) {
 		t.Errorf("Unmarshaled UserOperation does not match the original.\nOriginal: %+v\nUnmarshaled: %+v", originalOp, unmarshaledOp)
+	}
+}
+
+func TestIntentUserOperation_UnmarshalJSON(t *testing.T) {
+	// Create an Intent UserOperation
+	originalOp := &UserOperation{
+		Sender:               common.HexToAddress("0x3068c2408c01bECde4BcCB9f246b56651BE1d12D"),
+		Nonce:                big.NewInt(15),
+		InitCode:             []byte("init code"),
+		CallData:             []byte(`{"chainId":80001, sender":"0x0A7199a96fdf0252E09F76545c1eF2be3692F46b","kind":"swap","hash":"","sellToken":"TokenA","buyToken":"TokenB","sellAmount":10,"buyAmount":5,"partiallyFillable":false,"status":"Received","createdAt":0,"expirationAt":0}`),
+		CallGasLimit:         big.NewInt(12068),
+		VerificationGasLimit: big.NewInt(58592),
+		PreVerificationGas:   big.NewInt(47996),
+		MaxFeePerGas:         big.NewInt(77052194170),
+		MaxPriorityFeePerGas: big.NewInt(77052194106),
+		PaymasterAndData:     []byte("paymaster data"),
+		Signature:            []byte("signature"),
+	}
+
+	// Marshal the original UserOperation to JSON
+	marshaledJSON, err := originalOp.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+
+	t.Log(string(marshaledJSON))
+
+	// Unmarshal the JSON back into a new UserOperation instance
+	var unmarshaledOp UserOperation
+	if err := unmarshaledOp.UnmarshalJSON(marshaledJSON); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+
+	// Compare the original and unmarshaled instances
+	if !reflect.DeepEqual(originalOp, &unmarshaledOp) {
+		t.Errorf("Unmarshaled UserOperation does not match the original.\nOriginal: %+v\nUnmarshaled: %+v", originalOp, unmarshaledOp)
+	}
+}
+
+func TestIntentUserOperation_RawJSON(t *testing.T) {
+	// Simulate command line input
+	rawJSON := `
+{
+   "sender":"0x6B5f6558CB8B3C8Fec2DA0B1edA9b9d5C064ca47",
+   "nonce":"0x8",
+   "initCode":"0x",
+   "callData":"{\"chainId\":80001, \"sender\":\"0x0A7199a96fdf0252E09F76545c1eF2be3692F46b\",\"kind\":\"swap\",\"hash\":\"\",\"sellToken\":\"TokenA\",\"buyToken\":\"TokenB\",\"sellAmount\":10,\"buyAmount\":5,\"partiallyFillable\":false,\"status\":\"Received\",\"createdAt\":0,\"expirationAt\":0}",
+   "callGasLimit":"0x2dc6c0",
+   "verificationGasLimit":"0x2dc6c0",
+   "preVerificationGas":"0xbb70",
+   "maxFeePerGas":"0x7e498f31e",
+   "maxPriorityFeePerGas":"0x7e498f300",
+   "paymasterAndData":"0x",
+   "signature":"0x92f25342760a82b7e5649ed7c6d2d7cb93c0093f66c916d7e57de4af0ae00e2b0524bf364778c6b30c491354be332a1ce521e8a57c5e26f94f8069a404520e931b"
+}	
+	`
+
+	// Unmarshal the JSON back into a new UserOperation instance
+	var unmarshaledOp UserOperation
+	if err := unmarshaledOp.UnmarshalJSON([]byte(rawJSON)); err != nil {
+		t.Fatalf("UnmarshalJSON failed: %v", err)
+	}
+	if unmarshaledOp.Sender.String() != "0x6B5f6558CB8B3C8Fec2DA0B1edA9b9d5C064ca47" {
+		t.Errorf("Sender does not match expected value")
+	}
+	if unmarshaledOp.Nonce.String() != "8" {
+		t.Errorf("Nonce does not match expected value")
+	}
+	if len(unmarshaledOp.InitCode) != 0 {
+		t.Errorf("InitCode does not match expected value")
+	}
+	if unmarshaledOp.CallData == nil {
+		t.Errorf("CallData does not match expected value")
+	}
+	if !unmarshaledOp.HasIntent() {
+		t.Errorf("HasIntent does not match expected value")
+	}
+	intent, err := unmarshaledOp.GetIntent()
+	if err != nil {
+		t.Errorf("GetIntent returned error: %v", err)
+	}
+	if intent == nil {
+		t.Fatalf("GetIntent returned nil")
+	}
+	if intent.ChainID.Uint64() != 80001 {
+		t.Errorf("GetIntent returned invalid chainID")
+	}
+	if intent.Sender != "0x0A7199a96fdf0252E09F76545c1eF2be3692F46b" {
+		t.Errorf("GetIntent returned invalid sender")
+	}
+	if intent.Kind != Swap {
+		t.Errorf("GetIntent returned invalid kind")
+	}
+	if intent.Hash != "" {
+		t.Errorf("GetIntent returned invalid hash")
+	}
+	if intent.SellToken != "TokenA" {
+		t.Errorf("GetIntent returned invalid sellToken")
+	}
+	if intent.BuyToken != "TokenB" {
+		t.Errorf("GetIntent returned invalid buyToken")
+	}
+	if intent.SellAmount != 10 {
+		t.Errorf("GetIntent returned invalid sellAmount")
+	}
+	if intent.BuyAmount != 5 {
+		t.Errorf("GetIntent returned invalid buyAmount")
+	}
+	if intent.PartiallyFillable {
+		t.Errorf("GetIntent returned invalid partiallyFillable")
+	}
+	if intent.Status != Received {
+		t.Errorf("GetIntent returned invalid status")
+	}
+	if intent.CreatedAt != 0 {
+		t.Errorf("GetIntent returned invalid createdAt")
+	}
+	if intent.ExpirationAt != 0 {
+		t.Errorf("GetIntent returned invalid expirationAt")
+	}
+	if unmarshaledOp.CallGasLimit.String() != "3000000" {
+		t.Errorf("CallGasLimit does not match expected value")
+	}
+	if unmarshaledOp.VerificationGasLimit.String() != "3000000" {
+		t.Errorf("VerificationGasLimit does not match expected value")
+	}
+	if unmarshaledOp.PreVerificationGas.String() != "47984" {
+		t.Errorf("PreVerificationGas does not match expected value")
+	}
+	if unmarshaledOp.MaxFeePerGas.String() != "33900000030" {
+		t.Errorf("MaxFeePerGas does not match expected value")
+	}
+	if unmarshaledOp.MaxPriorityFeePerGas.String() != "33900000000" {
+		t.Errorf("MaxPriorityFeePerGas does not match expected value")
+	}
+	if len(unmarshaledOp.PaymasterAndData) != 0 {
+		t.Errorf("PaymasterAndData does not match expected value")
+	}
+
+	if hexutil.Encode(unmarshaledOp.Signature) != "0x92f25342760a82b7e5649ed7c6d2d7cb93c0093f66c916d7e57de4af0ae00e2b0524bf364778c6b30c491354be332a1ce521e8a57c5e26f94f8069a404520e931b" {
+		t.Errorf("Signature does not match expected value")
 	}
 }
 

--- a/userops_ext_test.go
+++ b/userops_ext_test.go
@@ -146,20 +146,20 @@ func TestUserOperation_UnmarshalJSON(t *testing.T) {
 	}
 
 	// Marshal the original UserOperation to JSON
-	marshalledJSON, err := originalOp.MarshalJSON()
+	marshaledJSON, err := originalOp.MarshalJSON()
 	if err != nil {
 		t.Fatalf("MarshalJSON failed: %v", err)
 	}
 
 	// Unmarshal the JSON back into a new UserOperation instance
-	var unmarshalledOp UserOperation
-	if err := unmarshalledOp.UnmarshalJSON(marshalledJSON); err != nil {
+	var unmarshaledOp UserOperation
+	if err := unmarshaledOp.UnmarshalJSON(marshaledJSON); err != nil {
 		t.Fatalf("UnmarshalJSON failed: %v", err)
 	}
 
-	// Compare the original and unmarshalled instances
-	if !reflect.DeepEqual(originalOp, &unmarshalledOp) {
-		t.Errorf("Unmarshalled UserOperation does not match the original.\nOriginal: %+v\nUnmarshalled: %+v", originalOp, unmarshalledOp)
+	// Compare the original and unmarshaled instances
+	if !reflect.DeepEqual(originalOp, &unmarshaledOp) {
+		t.Errorf("Unmarshaled UserOperation does not match the original.\nOriginal: %+v\nUnmarshaled: %+v", originalOp, unmarshaledOp)
 	}
 }
 


### PR DESCRIPTION
- fix: Typo marshal with 2 L
- feat: Unmarshal Intent UserOps
Issue was that Intent UserOps contain text JSON in the `calldata` field rather than hex encoded EVM.

Note: this feature is needed for testing on-chain submissions of unsolved Intent Userops with the SDK. 
Unmashaling solved Intent UserOps, if needed, can be added later.
