### PR TITLE
Fixes i.e., set calldata in correct representation

### DIFF
--- a/userops_ext.go
+++ b/userops_ext.go
@@ -371,7 +371,7 @@ func (op *UserOperation) String() string {
 		if len(b) == 0 {
 			return "0x" // default for empty byte slice
 		}
-		if b[0] == '0' && b[1] == 'x' {
+		if len(b) >= 2 && b[0] == '0' && b[1] == 'x' {
 			return string(b)
 		}
 

--- a/userops_ext.go
+++ b/userops_ext.go
@@ -254,12 +254,14 @@ func (op *UserOperation) SetIntent(intentJSON string) error {
 // EVM instructions in the CallData field.
 //
 // Parameters:
-//   - callDataValue: A byte slice containing the EVM instructions to be set in the CallData field.
+//   - callDataValue: A hex-encoded or byte-level representation containing the
+//     EVM instructions to be set in the CallData field.
 //
 // Returns:
 //   - error: An error is returned if the operation's status is invalid, if there is no signature
 //     in the UserOperation when required, or if any other issue arises during the process.
-//     Otherwise, nil is returned, indicating successful setting of the EVM instructions.
+//     Otherwise, nil is returned, indicating successful setting of the EVM instructions in byte-level
+//     representation.
 func (op *UserOperation) SetEVMInstructions(callDataValue []byte) error {
 	status, err := op.Validate()
 	if err != nil {
@@ -282,7 +284,17 @@ func (op *UserOperation) SetEVMInstructions(callDataValue []byte) error {
 		// Clear the Intent JSON from CallData as it's now moved to Signature.
 	}
 
+	if len(callDataValue) >= 2 && callDataValue[0] == '0' && callDataValue[1] == 'x' {
+		// `Decode` allows using the source as the destination
+		callDataValue, err = hexutil.Decode(string(callDataValue))
+		if err != nil {
+			return fmt.Errorf("invalid hex data: %w", err)
+		}
+	}
+
+	// Assign byte-level representation
 	op.CallData = callDataValue
+
 	return nil
 }
 

--- a/userops_ext_test.go
+++ b/userops_ext_test.go
@@ -229,7 +229,7 @@ func TestValidateUserOperation(t *testing.T) {
 	tests := []struct {
 		name           string
 		userOp         *UserOperation
-		expectedStatus userOpSolvedStatus
+		expectedStatus UserOpSolvedStatus
 		expectedError  error
 	}{
 		{
@@ -238,7 +238,7 @@ func TestValidateUserOperation(t *testing.T) {
 				CallData:  []byte{},
 				Signature: []byte{},
 			},
-			expectedStatus: conventionalUserOp,
+			expectedStatus: ConventionalUserOp,
 			expectedError:  nil,
 		},
 		{
@@ -247,7 +247,7 @@ func TestValidateUserOperation(t *testing.T) {
 				CallData:  []byte{},
 				Signature: makeHexEncodedSignature(SignatureLength),
 			},
-			expectedStatus: conventionalUserOp,
+			expectedStatus: ConventionalUserOp,
 			expectedError:  nil,
 		},
 		{
@@ -255,7 +255,7 @@ func TestValidateUserOperation(t *testing.T) {
 			userOp: &UserOperation{
 				CallData: []byte(mockIntentJSON()),
 			},
-			expectedStatus: unsolvedUserOp,
+			expectedStatus: UnsolvedUserOp,
 			expectedError:  nil,
 		},
 		{
@@ -264,7 +264,7 @@ func TestValidateUserOperation(t *testing.T) {
 				CallData:  []byte(mockIntentJSON()),
 				Signature: append(makeHexEncodedSignature(SignatureLength), mockIntentJSON()...),
 			},
-			expectedStatus: unknownUserOp,
+			expectedStatus: UnknownUserOp,
 			expectedError:  ErrDoubleIntentDef,
 		},
 		{
@@ -273,7 +273,7 @@ func TestValidateUserOperation(t *testing.T) {
 				CallData:  mockCallData(),
 				Signature: makeHexEncodedSignature(SignatureLength),
 			},
-			expectedStatus: solvedUserOp,
+			expectedStatus: SolvedUserOp,
 			expectedError:  nil,
 		},
 		{
@@ -281,16 +281,16 @@ func TestValidateUserOperation(t *testing.T) {
 			userOp: &UserOperation{
 				CallData: mockCallData(),
 			},
-			expectedStatus: solvedUserOp,
+			expectedStatus: SolvedUserOp,
 			expectedError:  ErrNoSignatureValue,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			status, err := test.userOp.validateUserOperation()
+			status, err := test.userOp.Validate()
 			if status != test.expectedStatus || err != test.expectedError {
-				status, err := test.userOp.validateUserOperation()
+				status, err := test.userOp.Validate()
 				t.Errorf("Test: %s, Expected status: %v, got: %v, Expected error: %v, got: %v", test.name, test.expectedStatus, status, test.expectedError, err)
 			}
 		})
@@ -317,14 +317,14 @@ func TestValidateUserOperation_Conventional(t *testing.T) {
 	userOp := &UserOperation{}                                                                 // Empty CallData and no Signature
 	userOpWithSignature := &UserOperation{Signature: makeHexEncodedSignature(SignatureLength)} // Empty CallData and valid Signature
 
-	status, err := userOp.validateUserOperation()
-	if status != conventionalUserOp || err != nil {
-		t.Errorf("validateUserOperation() = %v, %v; want %v, nil", status, err, conventionalUserOp)
+	status, err := userOp.Validate()
+	if status != ConventionalUserOp || err != nil {
+		t.Errorf("Validate() = %v, %v; want %v, nil", status, err, ConventionalUserOp)
 	}
 
-	status, err = userOpWithSignature.validateUserOperation()
-	if status != conventionalUserOp || err != nil {
-		t.Errorf("validateUserOperation() = %v, %v; want %v, nil", status, err, conventionalUserOp)
+	status, err = userOpWithSignature.Validate()
+	if status != ConventionalUserOp || err != nil {
+		t.Errorf("Validate() = %v, %v; want %v, nil", status, err, ConventionalUserOp)
 	}
 }
 


### PR DESCRIPTION
- feat: export Validate()
- fix: add safety check
- fix: Save calldata in byte-level representation
