### PR TITLE
Implement custom marshalling

### DIFF
--- a/userops_ext.go
+++ b/userops_ext.go
@@ -55,6 +55,19 @@ func (u *UserOperationExt) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (u *UserOperationExt) MarshalJSON() ([]byte, error) {
+
+	aux := struct {
+		OriginalHashValue string `json:"original_hash_value"`
+		ProcessingStatus  string `json:"processing_status"`
+	}{
+		OriginalHashValue: u.OriginalHashValue,
+		ProcessingStatus:  u.ProcessingStatus.String(),
+	}
+
+	return json.Marshal(&aux)
+}
+
 // UserOpSolvedStatus is an enum type that defines the possible states of a
 // UserOperation's resolution.It indicates whether an operation is unsolved,
 // solved, conventional, or in an unknown state.
@@ -175,6 +188,7 @@ func ExtractJSONFromField(fieldData string) (string, bool) {
 	if fieldData != "" {
 		var intent pb.Intent
 		err := protojson.Unmarshal([]byte(fieldData), &intent)
+		fmt.Println(err)
 		if err != nil {
 			return "", false
 		}

--- a/userops_ext.go
+++ b/userops_ext.go
@@ -188,7 +188,6 @@ func ExtractJSONFromField(fieldData string) (string, bool) {
 	if fieldData != "" {
 		var intent pb.Intent
 		err := protojson.Unmarshal([]byte(fieldData), &intent)
-		fmt.Println(err)
 		if err != nil {
 			return "", false
 		}

--- a/userops_ext_test.go
+++ b/userops_ext_test.go
@@ -718,6 +718,49 @@ func Test_Intent_UserOperationString(t *testing.T) {
 	}
 }
 
+func TestUserOperationExt_MarshalJSON(t *testing.T) {
+	tt := []struct {
+		name           string
+		expectedStatus string
+		status         pb.ProcessingStatus
+	}{
+		{
+			name:           "status received",
+			expectedStatus: "PROCESSING_STATUS_RECEIVED",
+			status:         pb.ProcessingStatus_PROCESSING_STATUS_RECEIVED,
+		},
+		{
+			name:           "status unspecified",
+			expectedStatus: "PROCESSING_STATUS_UNSPECIFIED",
+			status:         pb.ProcessingStatus_PROCESSING_STATUS_UNSPECIFIED,
+		},
+		{
+			name:           "status solved",
+			expectedStatus: "PROCESSING_STATUS_SOLVED",
+			status:         pb.ProcessingStatus_PROCESSING_STATUS_SOLVED,
+		},
+	}
+
+	for _, v := range tt {
+		userExt := &UserOperationExt{
+			ProcessingStatus:  v.status,
+			OriginalHashValue: "0xhash",
+		}
+
+		value, err := json.Marshal(userExt)
+		require.NoError(t, err)
+
+		var s struct {
+			ProcessingStatus string `json:"processing_status"`
+		}
+
+		err = json.Unmarshal(value, &s)
+		require.NoError(t, err)
+
+		require.Equal(t, v.expectedStatus, s.ProcessingStatus)
+	}
+}
+
 func TestUserOperationRawJSON(t *testing.T) {
 	rawJSON := `{
         "user_ops": [


### PR DESCRIPTION
This PR is an update to #32 .`ProcessingStatus` protobuf model in TS correctly converts the integer to string
when you use `Intent.toJSON(intent)` but there is no Go equivalent so the solver will always keep sending `processing_status` as an integer if you use the struct to build the model directly. 

See `sendToSolver` in the bundler repo.

This PR fixes that by taking in the integer but normalising to a string ( human readable ) and brings consistency to the 
behavior 